### PR TITLE
Enable order requests on Google Play and iTunes pages

### DIFF
--- a/googleplay.html
+++ b/googleplay.html
@@ -91,6 +91,18 @@
     button:hover {
         background-color: #d4a818;
     }
+    form {
+        display: none;
+        background-color: #1a1a1a;
+        padding: 15px;
+        border-radius: 6px;
+        margin-top: 10px;
+    }
+    input, select {
+        width: 100%;
+        padding: 8px;
+        margin: 5px 0;
+    }
     footer {
         background-color: #1a1a1a;
         padding: 10px;
@@ -122,37 +134,132 @@
         <img src="image/Googleplay.jpg" alt="Google Play 5$">
         <h3>بطاقة Google Play 5$</h3>
         <p>السعر: 2 دولار ≈ 80 أوقية</p>
-        <button>اطلب الآن</button>
+        <button onclick="showForm(this, 'Google Play', 'بطاقة 5$')">اطلب الآن</button>
+        <form>
+            <input type="text" placeholder="رقم واتسابك" class="whats">
+            <select class="pay">
+                <option value="بنكيلي">بنكيلي</option>
+                <option value="السداد">السداد</option>
+                <option value="مصرفي">مصرفي</option>
+            </select>
+            <input type="file" class="receipt">
+            <button type="button" onclick="sendOrder(this)">إرسال الطلب</button>
+            <p class="status"></p>
+        </form>
     </div>
     <div class="offer-card">
         <img src="image/Googleplay.jpg" alt="Google Play 10$">
         <h3>بطاقة Google Play 10$</h3>
         <p>السعر: 5 دولار ≈ 200 أوقية</p>
-        <button>اطلب الآن</button>
+        <button onclick="showForm(this, 'Google Play', 'بطاقة 10$')">اطلب الآن</button>
+        <form>
+            <input type="text" placeholder="رقم واتسابك" class="whats">
+            <select class="pay">
+                <option value="بنكيلي">بنكيلي</option>
+                <option value="السداد">السداد</option>
+                <option value="مصرفي">مصرفي</option>
+            </select>
+            <input type="file" class="receipt">
+            <button type="button" onclick="sendOrder(this)">إرسال الطلب</button>
+            <p class="status"></p>
+        </form>
     </div>
     <div class="offer-card">
         <img src="image/Googleplay.jpg" alt="Google Play 15$">
         <h3>بطاقة Google Play 15$</h3>
         <p>السعر: 7.5 دولار ≈ 300 أوقية</p>
-        <button>اطلب الآن</button>
+        <button onclick="showForm(this, 'Google Play', 'بطاقة 15$')">اطلب الآن</button>
+        <form>
+            <input type="text" placeholder="رقم واتسابك" class="whats">
+            <select class="pay">
+                <option value="بنكيلي">بنكيلي</option>
+                <option value="السداد">السداد</option>
+                <option value="مصرفي">مصرفي</option>
+            </select>
+            <input type="file" class="receipt">
+            <button type="button" onclick="sendOrder(this)">إرسال الطلب</button>
+            <p class="status"></p>
+        </form>
     </div>
     <div class="offer-card">
         <img src="image/Googleplay.jpg" alt="Google Play 25$">
         <h3>بطاقة Google Play 25$</h3>
         <p>السعر: 12 دولار ≈ 480 أوقية</p>
-        <button>اطلب الآن</button>
+        <button onclick="showForm(this, 'Google Play', 'بطاقة 25$')">اطلب الآن</button>
+        <form>
+            <input type="text" placeholder="رقم واتسابك" class="whats">
+            <select class="pay">
+                <option value="بنكيلي">بنكيلي</option>
+                <option value="السداد">السداد</option>
+                <option value="مصرفي">مصرفي</option>
+            </select>
+            <input type="file" class="receipt">
+            <button type="button" onclick="sendOrder(this)">إرسال الطلب</button>
+            <p class="status"></p>
+        </form>
     </div>
     <div class="offer-card">
         <img src="image/Googleplay.jpg" alt="Google Play 50$">
         <h3>بطاقة Google Play 50$</h3>
         <p>السعر: 23 دولار ≈ 920 أوقية</p>
-        <button>اطلب الآن</button>
+        <button onclick="showForm(this, 'Google Play', 'بطاقة 50$')">اطلب الآن</button>
+        <form>
+            <input type="text" placeholder="رقم واتسابك" class="whats">
+            <select class="pay">
+                <option value="بنكيلي">بنكيلي</option>
+                <option value="السداد">السداد</option>
+                <option value="مصرفي">مصرفي</option>
+            </select>
+            <input type="file" class="receipt">
+            <button type="button" onclick="sendOrder(this)">إرسال الطلب</button>
+            <p class="status"></p>
+        </form>
     </div>
 </section>
 
 <footer>
     © 2025 LD Top-Up | واتساب الدعم: +22241380130
 </footer>
+
+<script>
+let selectedCat = '', selectedOffer = '';
+
+function showForm(btn, cat, offer){
+    selectedCat = cat;
+    selectedOffer = offer;
+    const form = btn.nextElementSibling;
+    form.style.display = form.style.display === 'block' ? 'none' : 'block';
+}
+
+function sendOrder(btn){
+    const form = btn.parentElement;
+    const whats = form.querySelector('.whats').value;
+    const pay = form.querySelector('.pay').value;
+    const file = form.querySelector('.receipt').files[0];
+    const status = form.querySelector('.status');
+
+    if(!whats || !file){
+        status.textContent = '⚠️ أدخل رقم واتساب وارفع صورة المعاملة';
+        return;
+    }
+
+    const botToken = "8186686903:AAGxBvjWzcbkxdu5l4GrR9bilH0Ua4AnYkM";
+    const chatId = "6660278825";
+    const formData = new FormData();
+    formData.append('chat_id', chatId);
+    formData.append('caption', `طلب جديد 🎮\n${selectedCat} - ${selectedOffer}\nواتساب: ${whats}\nدفع: ${pay}`);
+    formData.append('photo', file);
+
+    fetch(`https://api.telegram.org/bot${botToken}/sendPhoto`, {
+        method: 'POST',
+        body: formData
+    }).then(r=>{
+        status.textContent = '✅ تم إرسال الطلب بنجاح';
+    }).catch(e=>{
+        status.textContent = '❌ حصل خطأ في الإرسال';
+    });
+}
+</script>
 
 </body>
 </html>

--- a/itunes.html
+++ b/itunes.html
@@ -78,6 +78,30 @@
         margin: 0;
         color: #ccc;
     }
+    button {
+        background-color: #1e90ff;
+        border: none;
+        padding: 10px;
+        margin-top: 10px;
+        cursor: pointer;
+        border-radius: 5px;
+        font-weight: bold;
+    }
+    button:hover {
+        background-color: #187bcd;
+    }
+    form {
+        display: none;
+        background-color: #1a1a1a;
+        padding: 15px;
+        border-radius: 6px;
+        margin-top: 10px;
+    }
+    input, select {
+        width: 100%;
+        padding: 8px;
+        margin: 5px 0;
+    }
     footer {
         background-color: #1a1a1a;
         padding: 10px;
@@ -109,32 +133,132 @@
         <img src="image/Itunes.jpg">
         <h3>بطاقة $5</h3>
         <p>190 أوقية</p>
+        <button onclick="showForm(this, 'iTunes', 'بطاقة $5')">اطلب الآن</button>
+        <form>
+            <input type="text" placeholder="رقم واتسابك" class="whats">
+            <select class="pay">
+                <option value="بنكيلي">بنكيلي</option>
+                <option value="السداد">السداد</option>
+                <option value="مصرفي">مصرفي</option>
+            </select>
+            <input type="file" class="receipt">
+            <button type="button" onclick="sendOrder(this)">إرسال الطلب</button>
+            <p class="status"></p>
+        </form>
     </div>
     <div class="offer-card">
         <img src="image/Itunes.jpg">
         <h3>بطاقة $10</h3>
         <p>380 أوقية</p>
+        <button onclick="showForm(this, 'iTunes', 'بطاقة $10')">اطلب الآن</button>
+        <form>
+            <input type="text" placeholder="رقم واتسابك" class="whats">
+            <select class="pay">
+                <option value="بنكيلي">بنكيلي</option>
+                <option value="السداد">السداد</option>
+                <option value="مصرفي">مصرفي</option>
+            </select>
+            <input type="file" class="receipt">
+            <button type="button" onclick="sendOrder(this)">إرسال الطلب</button>
+            <p class="status"></p>
+        </form>
     </div>
     <div class="offer-card">
         <img src="image/Itunes.jpg">
         <h3>بطاقة $15</h3>
         <p>570 أوقية</p>
+        <button onclick="showForm(this, 'iTunes', 'بطاقة $15')">اطلب الآن</button>
+        <form>
+            <input type="text" placeholder="رقم واتسابك" class="whats">
+            <select class="pay">
+                <option value="بنكيلي">بنكيلي</option>
+                <option value="السداد">السداد</option>
+                <option value="مصرفي">مصرفي</option>
+            </select>
+            <input type="file" class="receipt">
+            <button type="button" onclick="sendOrder(this)">إرسال الطلب</button>
+            <p class="status"></p>
+        </form>
     </div>
     <div class="offer-card">
         <img src="image/Itunes.jpg">
         <h3>بطاقة $25</h3>
         <p>950 أوقية</p>
+        <button onclick="showForm(this, 'iTunes', 'بطاقة $25')">اطلب الآن</button>
+        <form>
+            <input type="text" placeholder="رقم واتسابك" class="whats">
+            <select class="pay">
+                <option value="بنكيلي">بنكيلي</option>
+                <option value="السداد">السداد</option>
+                <option value="مصرفي">مصرفي</option>
+            </select>
+            <input type="file" class="receipt">
+            <button type="button" onclick="sendOrder(this)">إرسال الطلب</button>
+            <p class="status"></p>
+        </form>
     </div>
     <div class="offer-card">
         <img src="image/Itunes.jpg">
         <h3>بطاقة $50</h3>
         <p>1900 أوقية</p>
+        <button onclick="showForm(this, 'iTunes', 'بطاقة $50')">اطلب الآن</button>
+        <form>
+            <input type="text" placeholder="رقم واتسابك" class="whats">
+            <select class="pay">
+                <option value="بنكيلي">بنكيلي</option>
+                <option value="السداد">السداد</option>
+                <option value="مصرفي">مصرفي</option>
+            </select>
+            <input type="file" class="receipt">
+            <button type="button" onclick="sendOrder(this)">إرسال الطلب</button>
+            <p class="status"></p>
+        </form>
     </div>
 </section>
 
 <footer>
     © 2025 LD Top-Up | واتساب الدعم: +22241380130
 </footer>
+
+<script>
+let selectedCat = '', selectedOffer = '';
+
+function showForm(btn, cat, offer){
+    selectedCat = cat;
+    selectedOffer = offer;
+    const form = btn.nextElementSibling;
+    form.style.display = form.style.display === 'block' ? 'none' : 'block';
+}
+
+function sendOrder(btn){
+    const form = btn.parentElement;
+    const whats = form.querySelector('.whats').value;
+    const pay = form.querySelector('.pay').value;
+    const file = form.querySelector('.receipt').files[0];
+    const status = form.querySelector('.status');
+
+    if(!whats || !file){
+        status.textContent = '⚠️ أدخل رقم واتساب وارفع صورة المعاملة';
+        return;
+    }
+
+    const botToken = "8186686903:AAGxBvjWzcbkxdu5l4GrR9bilH0Ua4AnYkM";
+    const chatId = "6660278825";
+    const formData = new FormData();
+    formData.append('chat_id', chatId);
+    formData.append('caption', `طلب جديد 🎮\n${selectedCat} - ${selectedOffer}\nواتساب: ${whats}\nدفع: ${pay}`);
+    formData.append('photo', file);
+
+    fetch(`https://api.telegram.org/bot${botToken}/sendPhoto`, {
+        method: 'POST',
+        body: formData
+    }).then(r=>{
+        status.textContent = '✅ تم إرسال الطلب بنجاح';
+    }).catch(e=>{
+        status.textContent = '❌ حصل خطأ في الإرسال';
+    });
+}
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add interactive order forms to Google Play cards without player ID requirement
- Introduce request buttons and matching order forms to iTunes offers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f6f32888832a813d1f1f123b609c