### PR TITLE
Add language dropdown and themed navigation

### DIFF
--- a/freefire.html
+++ b/freefire.html
@@ -8,9 +8,13 @@
   body { font-family: sans-serif; background: #0b0f1a; color: #fff; margin:0; }
   header { background: #0d1626; padding: 15px; display:flex; flex-wrap:wrap; justify-content:space-between; align-items:center; gap:10px; }
   header nav { display:flex; flex-wrap:wrap; gap:10px; }
-  header nav a { color: #4db8ff; text-decoration:none; }
-  .lang-switch { display:flex; gap:5px; }
-  .lang-switch button { background:none; border:none; color:#4db8ff; cursor:pointer; font-weight:bold; }
+  header nav a { color: #4db8ff; text-decoration:none; border:2px solid #4db8ff; padding:5px 10px; border-radius:5px; }
+  header nav a:hover { background:#223; }
+  .lang-switch { position:relative; }
+  #lang-toggle { background:none; border:2px solid #4db8ff; color:#4db8ff; cursor:pointer; font-weight:bold; padding:5px 10px; border-radius:5px; }
+  .lang-menu { display:none; position:absolute; top:100%; right:0; background:#0d1626; border:1px solid #223; border-radius:5px; }
+  .lang-menu button { display:block; width:100%; background:none; border:none; color:#4db8ff; cursor:pointer; padding:5px 10px; text-align:left; }
+  .lang-menu button:hover { background:#223; }
   footer { background: #0d1626; padding: 15px; text-align:center; }
   h1 { color: #4db8ff; text-align: center; }
   .offers { display:grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap:15px; padding:20px; }
@@ -37,9 +41,12 @@
     <a href="itunes.html" data-i18n="nav-itunes">iTunes</a>
   </nav>
   <div class="lang-switch">
-    <button data-lang="ar">🇲🇷 العربية</button>
-    <button data-lang="fr">🇫🇷 Français</button>
-    <button data-lang="en">🇺🇸 English</button>
+    <button id="lang-toggle">🌐</button>
+    <div class="lang-menu">
+      <button data-lang="ar">🇲🇷 العربية</button>
+      <button data-lang="fr">🇫🇷 Français</button>
+      <button data-lang="en">🇺🇸 English</button>
+    </div>
   </div>
 </header>
 

--- a/googleplay.html
+++ b/googleplay.html
@@ -33,20 +33,47 @@
         color: #fff;
         text-decoration: none;
         font-weight: bold;
+        border: 2px solid #0f9d58;
+        padding: 5px 10px;
+        border-radius: 5px;
     }
     nav a:hover {
-        color: #f8c21a;
+        background-color: rgba(15,157,88,0.2);
     }
     .lang-switch {
-        display: flex;
-        gap: 5px;
+        position: relative;
     }
-    .lang-switch button {
+    #lang-toggle {
+        background: none;
+        border: 2px solid #0f9d58;
+        color: #fff;
+        cursor: pointer;
+        font-weight: bold;
+        padding: 5px 10px;
+        border-radius: 5px;
+    }
+    .lang-menu {
+        display: none;
+        position: absolute;
+        top: 100%;
+        right: 0;
+        background-color: #1a1a1a;
+        border: 1px solid #333;
+        border-radius: 5px;
+        z-index: 10;
+    }
+    .lang-menu button {
+        display: block;
+        width: 100%;
         background: none;
         border: none;
         color: #fff;
         cursor: pointer;
-        font-weight: bold;
+        padding: 5px 10px;
+        text-align: left;
+    }
+    .lang-menu button:hover {
+        background-color: #333;
     }
     .hero {
         background-image: url('https://www.amazon.com/Google-Play-Gift-Code-mail/dp/B074T91QTZ');
@@ -144,9 +171,12 @@
         <a href="itunes.html" data-i18n="nav-itunes">iTunes</a>
     </nav>
     <div class="lang-switch">
-        <button data-lang="ar">🇲🇷 العربية</button>
-        <button data-lang="fr">🇫🇷 Français</button>
-        <button data-lang="en">🇺🇸 English</button>
+        <button id="lang-toggle">🌐</button>
+        <div class="lang-menu">
+            <button data-lang="ar">🇲🇷 العربية</button>
+            <button data-lang="fr">🇫🇷 Français</button>
+            <button data-lang="en">🇺🇸 English</button>
+        </div>
     </div>
 </header>
 

--- a/index.html
+++ b/index.html
@@ -33,20 +33,47 @@
         color: #fff;
         text-decoration: none;
         font-weight: bold;
+        border: 2px solid #f8c21a;
+        padding: 5px 10px;
+        border-radius: 5px;
     }
     nav a:hover {
-        color: #f8c21a;
+        background-color: rgba(248,194,26,0.2);
     }
     .lang-switch {
-        display: flex;
-        gap: 5px;
+        position: relative;
     }
-    .lang-switch button {
+    #lang-toggle {
+        background: none;
+        border: 2px solid #f8c21a;
+        color: #fff;
+        cursor: pointer;
+        font-weight: bold;
+        padding: 5px 10px;
+        border-radius: 5px;
+    }
+    .lang-menu {
+        display: none;
+        position: absolute;
+        top: 100%;
+        right: 0;
+        background-color: #1a1a1a;
+        border: 1px solid #333;
+        border-radius: 5px;
+        z-index: 10;
+    }
+    .lang-menu button {
+        display: block;
+        width: 100%;
         background: none;
         border: none;
         color: #fff;
         cursor: pointer;
-        font-weight: bold;
+        padding: 5px 10px;
+        text-align: left;
+    }
+    .lang-menu button:hover {
+        background-color: #333;
     }
     .hero {
         background-image: url('https://cdn.cloudflare.steamstatic.com/steam/apps/578080/header.jpg');
@@ -123,9 +150,12 @@
         <a href="itunes.html" data-i18n="nav-itunes">iTunes</a>
     </nav>
     <div class="lang-switch">
-        <button data-lang="ar">🇲🇷 العربية</button>
-        <button data-lang="fr">🇫🇷 Français</button>
-        <button data-lang="en">🇺🇸 English</button>
+        <button id="lang-toggle">🌐</button>
+        <div class="lang-menu">
+            <button data-lang="ar">🇲🇷 العربية</button>
+            <button data-lang="fr">🇫🇷 Français</button>
+            <button data-lang="en">🇺🇸 English</button>
+        </div>
     </div>
 </header>
 
@@ -135,7 +165,7 @@
 
 <section class="categories">
     <div class="category-card" onclick="location.href='pubg.html'">
-        <img src="https://cdn1.dotesports.com/wp-content/uploads/2023/06/02150928/pubg-mobile.jpg" alt="PUBG Mobile">
+        <img src="image/UC.jpg" alt="PUBG Mobile">
         <h3>PUBG Mobile</h3>
     </div>
     <div class="category-card" onclick="location.href='freefire.html'">
@@ -143,11 +173,11 @@
         <h3>Free Fire</h3>
     </div>
     <div class="category-card" onclick="location.href='googleplay.html'">
-        <img src="https://www.androidauthority.com/wp-content/uploads/2021/05/Google-Play-Store-Logo-2021-920x470.jpg" alt="Google Play">
+        <img src="image/Googleplay.jpg" alt="Google Play">
         <h3>Google Play</h3>
     </div>
     <div class="category-card" onclick="location.href='itunes.html'">
-        <img src="https://is1-ssl.mzstatic.com/image/thumb/Purple116/v4/78/8a/b2/788ab2f1-414d-9407-900d-016e08f3c10b/source/512x512bb.jpg" alt="iTunes">
+        <img src="image/Itunes.jpg" alt="iTunes">
         <h3>iTunes</h3>
     </div>
 </section>

--- a/itunes.html
+++ b/itunes.html
@@ -33,20 +33,47 @@
         color: #fff;
         text-decoration: none;
         font-weight: bold;
+        border: 2px solid #1e90ff;
+        padding: 5px 10px;
+        border-radius: 5px;
     }
     nav a:hover {
-        color: #1e90ff;
+        background-color: rgba(30,144,255,0.2);
     }
     .lang-switch {
-        display: flex;
-        gap: 5px;
+        position: relative;
     }
-    .lang-switch button {
+    #lang-toggle {
+        background: none;
+        border: 2px solid #1e90ff;
+        color: #fff;
+        cursor: pointer;
+        font-weight: bold;
+        padding: 5px 10px;
+        border-radius: 5px;
+    }
+    .lang-menu {
+        display: none;
+        position: absolute;
+        top: 100%;
+        right: 0;
+        background-color: #1a1a1a;
+        border: 1px solid #333;
+        border-radius: 5px;
+        z-index: 10;
+    }
+    .lang-menu button {
+        display: block;
+        width: 100%;
         background: none;
         border: none;
         color: #fff;
         cursor: pointer;
-        font-weight: bold;
+        padding: 5px 10px;
+        text-align: left;
+    }
+    .lang-menu button:hover {
+        background-color: #333;
     }
     .hero {
         background-image: url('https://is1-ssl.mzstatic.com/image/thumb/Purple116/v4/78/8a/b2/788ab2f1-414d-9407-900d-016e08f3c10b/source/512x512bb.jpg');
@@ -143,9 +170,12 @@
         <a href="itunes.html" data-i18n="nav-itunes">iTunes</a>
     </nav>
     <div class="lang-switch">
-        <button data-lang="ar">🇲🇷 العربية</button>
-        <button data-lang="fr">🇫🇷 Français</button>
-        <button data-lang="en">🇺🇸 English</button>
+        <button id="lang-toggle">🌐</button>
+        <div class="lang-menu">
+            <button data-lang="ar">🇲🇷 العربية</button>
+            <button data-lang="fr">🇫🇷 Français</button>
+            <button data-lang="en">🇺🇸 English</button>
+        </div>
     </div>
 </header>
 

--- a/lang.js
+++ b/lang.js
@@ -30,7 +30,7 @@ const translationsMap = {
   },
   'error': {
     ar: '❌ حصل خطأ في الإرسال',
-    fr: '❌ Échec de l'envoi',
+    fr: "❌ Échec de l'envoi",
     en: '❌ Failed to send'
   },
   'footer': {
@@ -40,10 +40,11 @@ const translationsMap = {
   }
 };
 
-let currentLang = 'ar';
+let currentLang = localStorage.getItem('lang') || 'ar';
 
 function applyTranslations(lang) {
   currentLang = lang;
+  localStorage.setItem('lang', lang);
   document.querySelectorAll('[data-i18n]').forEach(el => {
     const key = el.dataset.i18n;
     if (translationsMap[key] && translationsMap[key][lang]) {
@@ -59,10 +60,22 @@ function applyTranslations(lang) {
 }
 
 function initTranslation() {
-  const buttons = document.querySelectorAll('.lang-switch button');
-  buttons.forEach(btn => {
-    btn.addEventListener('click', () => applyTranslations(btn.dataset.lang));
-  });
+  const toggle = document.getElementById('lang-toggle');
+  const menu = document.querySelector('.lang-menu');
+
+  if (toggle && menu) {
+    toggle.addEventListener('click', () => {
+      menu.style.display = menu.style.display === 'block' ? 'none' : 'block';
+    });
+
+    menu.querySelectorAll('button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        applyTranslations(btn.dataset.lang);
+        menu.style.display = 'none';
+      });
+    });
+  }
+
   applyTranslations(currentLang);
 }
 

--- a/pubg.html
+++ b/pubg.html
@@ -8,9 +8,13 @@
   body { font-family: sans-serif; background: #0d0d0d; color: #fff; margin:0; }
   header { background: #1a1a1a; padding: 15px; display:flex; flex-wrap:wrap; justify-content:space-between; align-items:center; gap:10px; }
   header nav { display:flex; flex-wrap:wrap; gap:10px; }
-  header nav a { color: gold; text-decoration:none; }
-  .lang-switch { display:flex; gap:5px; }
-  .lang-switch button { background:none; border:none; color:gold; cursor:pointer; font-weight:bold; }
+  header nav a { color: gold; text-decoration:none; border:2px solid gold; padding:5px 10px; border-radius:5px; }
+  header nav a:hover { background:#333; }
+  .lang-switch { position:relative; }
+  #lang-toggle { background:none; border:2px solid gold; color:gold; cursor:pointer; font-weight:bold; padding:5px 10px; border-radius:5px; }
+  .lang-menu { display:none; position:absolute; top:100%; right:0; background:#1a1a1a; border:1px solid #333; border-radius:5px; }
+  .lang-menu button { display:block; width:100%; background:none; border:none; color:gold; cursor:pointer; padding:5px 10px; text-align:left; }
+  .lang-menu button:hover { background:#333; }
   footer { background: #1a1a1a; padding: 15px; text-align:center; }
   h1 { color: gold; text-align: center; }
   .offers { display:grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap:15px; padding:20px; }
@@ -35,9 +39,12 @@
     <a href="itunes.html" data-i18n="nav-itunes">iTunes</a>
   </nav>
   <div class="lang-switch">
-    <button data-lang="ar">🇲🇷 العربية</button>
-    <button data-lang="fr">🇫🇷 Français</button>
-    <button data-lang="en">🇺🇸 English</button>
+    <button id="lang-toggle">🌐</button>
+    <div class="lang-menu">
+      <button data-lang="ar">🇲🇷 العربية</button>
+      <button data-lang="fr">🇫🇷 Français</button>
+      <button data-lang="en">🇺🇸 English</button>
+    </div>
   </div>
 </header>
 


### PR DESCRIPTION
## Summary
- Replace static language buttons with dropdown that applies translations and remembers choice
- Highlight page links with themed borders and use local images for home categories

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check lang.js && echo 'syntax ok'`

------
https://chatgpt.com/codex/tasks/task_e_68a2027ec1e4832a81608590163bad58