### PR TITLE
Apply translations to category titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,19 +166,19 @@
 <section class="categories">
     <div class="category-card" onclick="location.href='pubg.html'">
         <img src="image/UC.jpg" alt="PUBG Mobile">
-        <h3>PUBG Mobile</h3>
+        <h3 data-i18n="cat-pubg">PUBG Mobile</h3>
     </div>
     <div class="category-card" onclick="location.href='freefire.html'">
         <img src="image/Freefire.png" alt="Free Fire">
-        <h3>Free Fire</h3>
+        <h3 data-i18n="cat-freefire">Free Fire</h3>
     </div>
     <div class="category-card" onclick="location.href='googleplay.html'">
         <img src="image/Googleplay.jpg" alt="Google Play">
-        <h3>Google Play</h3>
+        <h3 data-i18n="cat-googleplay">Google Play</h3>
     </div>
     <div class="category-card" onclick="location.href='itunes.html'">
         <img src="image/Itunes.jpg" alt="iTunes">
-        <h3>iTunes</h3>
+        <h3 data-i18n="cat-itunes">iTunes</h3>
     </div>
 </section>
 

--- a/lang.js
+++ b/lang.js
@@ -4,6 +4,10 @@ const translationsMap = {
   'nav-freefire': { ar: 'Free Fire', fr: 'Free Fire', en: 'Free Fire' },
   'nav-googleplay': { ar: 'Google Play', fr: 'Google Play', en: 'Google Play' },
   'nav-itunes': { ar: 'iTunes', fr: 'iTunes', en: 'iTunes' },
+  'cat-pubg': { ar: 'ببجي موبايل', fr: 'PUBG Mobile', en: 'PUBG Mobile' },
+  'cat-freefire': { ar: 'فري فاير', fr: 'Free Fire', en: 'Free Fire' },
+  'cat-googleplay': { ar: 'جوجل بلاي', fr: 'Google Play', en: 'Google Play' },
+  'cat-itunes': { ar: 'آيتونز', fr: 'iTunes', en: 'iTunes' },
   'hero-index': {
     ar: 'شحن فوري وآمن لجميع الألعاب والبطاقات',
     fr: 'Recharge instantanée et sécurisée pour tous les jeux et cartes',


### PR DESCRIPTION
## Summary
- Add translation map entries for category card titles
- Hook category titles on the homepage into i18n system

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a20b0a7128832a921ec543da9b4045