### PR TITLE
Use MRU pricing and romanized bank names

### DIFF
--- a/freefire.html
+++ b/freefire.html
@@ -34,11 +34,11 @@
 
 <header>
   <nav>
-    <a href="index.html" data-i18n="nav-home">الرئيسية</a>
-    <a href="pubg.html" data-i18n="nav-pubg">PUBG</a>
-    <a href="freefire.html" data-i18n="nav-freefire">Free Fire</a>
-    <a href="googleplay.html" data-i18n="nav-googleplay">Google Play</a>
-    <a href="itunes.html" data-i18n="nav-itunes">iTunes</a>
+    <a href="index.html">Home</a>
+    <a href="pubg.html">PUBG</a>
+    <a href="freefire.html">Free Fire</a>
+    <a href="googleplay.html">Google Play</a>
+    <a href="itunes.html">iTunes</a>
   </nav>
   <div class="lang-switch">
     <button id="lang-toggle">🌐</button>
@@ -56,15 +56,15 @@
   <div class="offer">
     <img src="image/Freefire.jpg" alt="100 Diamonds">
     <h3>100 Diamonds</h3>
-    <p><span data-i18n="price">السعر:</span> 50 أوقية</p>
+    <p><span data-i18n="price">السعر:</span> 50 MRU</p>
     <button data-i18n="order" onclick="showForm(this, 'Free Fire', '100 Diamonds')">اطلب الآن</button>
     <form>
       <input type="text" placeholder="ID اللاعب" class="uid" data-i18n-placeholder="player-id">
       <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
       <select class="pay">
-        <option value="بنكيلي">بنكيلي</option>
-        <option value="السداد">السداد</option>
-        <option value="مصرفي">مصرفي</option>
+        <option value="bankily">bankily</option>
+        <option value="sedad">sedad</option>
+        <option value="masrvi">masrvi</option>
       </select>
       <input type="file" class="receipt">
       <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -75,15 +75,15 @@
   <div class="offer">
     <img src="image/Freefire.jpg" alt="310 Diamonds">
     <h3>310 Diamonds</h3>
-    <p><span data-i18n="price">السعر:</span> 145 أوقية</p>
+    <p><span data-i18n="price">السعر:</span> 145 MRU</p>
     <button data-i18n="order" onclick="showForm(this, 'Free Fire', '310 Diamonds')">اطلب الآن</button>
     <form>
       <input type="text" placeholder="ID اللاعب" class="uid" data-i18n-placeholder="player-id">
       <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
       <select class="pay">
-        <option value="بنكيلي">بنكيلي</option>
-        <option value="السداد">السداد</option>
-        <option value="مصرفي">مصرفي</option>
+        <option value="bankily">bankily</option>
+        <option value="sedad">sedad</option>
+        <option value="masrvi">masrvi</option>
       </select>
       <input type="file" class="receipt">
       <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -94,15 +94,15 @@
   <div class="offer">
     <img src="image/Freefire.jpg" alt="520 Diamonds">
     <h3>520 Diamonds</h3>
-    <p><span data-i18n="price">السعر:</span> 235 أوقية</p>
+    <p><span data-i18n="price">السعر:</span> 235 MRU</p>
     <button data-i18n="order" onclick="showForm(this, 'Free Fire', '520 Diamonds')">اطلب الآن</button>
     <form>
       <input type="text" placeholder="ID اللاعب" class="uid" data-i18n-placeholder="player-id">
       <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
       <select class="pay">
-        <option value="بنكيلي">بنكيلي</option>
-        <option value="السداد">السداد</option>
-        <option value="مصرفي">مصرفي</option>
+        <option value="bankily">bankily</option>
+        <option value="sedad">sedad</option>
+        <option value="masrvi">masrvi</option>
       </select>
       <input type="file" class="receipt">
       <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -113,15 +113,15 @@
   <div class="offer">
     <img src="image/Freefire.jpg" alt="1060 Diamonds">
     <h3>1060 Diamonds</h3>
-    <p><span data-i18n="price">السعر:</span> 460 أوقية</p>
+    <p><span data-i18n="price">السعر:</span> 460 MRU</p>
     <button data-i18n="order" onclick="showForm(this, 'Free Fire', '1060 Diamonds')">اطلب الآن</button>
     <form>
       <input type="text" placeholder="ID اللاعب" class="uid" data-i18n-placeholder="player-id">
       <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
       <select class="pay">
-        <option value="بنكيلي">بنكيلي</option>
-        <option value="السداد">السداد</option>
-        <option value="مصرفي">مصرفي</option>
+        <option value="bankily">bankily</option>
+        <option value="sedad">sedad</option>
+        <option value="masrvi">masrvi</option>
       </select>
       <input type="file" class="receipt">
       <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -132,15 +132,15 @@
   <div class="offer">
     <img src="image/Freefire.jpg" alt="2180 Diamonds">
     <h3>2180 Diamonds</h3>
-    <p><span data-i18n="price">السعر:</span> 920 أوقية</p>
+    <p><span data-i18n="price">السعر:</span> 920 MRU</p>
     <button data-i18n="order" onclick="showForm(this, 'Free Fire', '2180 Diamonds')">اطلب الآن</button>
     <form>
       <input type="text" placeholder="ID اللاعب" class="uid" data-i18n-placeholder="player-id">
       <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
       <select class="pay">
-        <option value="بنكيلي">بنكيلي</option>
-        <option value="السداد">السداد</option>
-        <option value="مصرفي">مصرفي</option>
+        <option value="bankily">bankily</option>
+        <option value="sedad">sedad</option>
+        <option value="masrvi">masrvi</option>
       </select>
       <input type="file" class="receipt">
       <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>

--- a/googleplay.html
+++ b/googleplay.html
@@ -164,11 +164,11 @@
 <header>
     <h1>LD Top-Up</h1>
     <nav>
-        <a href="index.html" data-i18n="nav-home">الرئيسية</a>
-        <a href="pubg.html" data-i18n="nav-pubg">PUBG</a>
-        <a href="freefire.html" data-i18n="nav-freefire">Free Fire</a>
-        <a href="googleplay.html" data-i18n="nav-googleplay">Google Play</a>
-        <a href="itunes.html" data-i18n="nav-itunes">iTunes</a>
+        <a href="index.html">Home</a>
+        <a href="pubg.html">PUBG</a>
+        <a href="freefire.html">Free Fire</a>
+        <a href="googleplay.html">Google Play</a>
+        <a href="itunes.html">iTunes</a>
     </nav>
     <div class="lang-switch">
         <button id="lang-toggle">🌐</button>
@@ -188,14 +188,14 @@
     <div class="offer-card">
         <img src="image/Googleplay.jpg" alt="Google Play 5$">
         <h3>بطاقة Google Play 5$</h3>
-        <p><span data-i18n="price">السعر:</span> 2 دولار ≈ 80 أوقية</p>
+        <p><span data-i18n="price">السعر:</span> 2 دولار ≈ 80 MRU</p>
         <button data-i18n="order" onclick="showForm(this, 'Google Play', 'بطاقة 5$')">اطلب الآن</button>
         <form>
             <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
             <select class="pay">
-                <option value="بنكيلي">بنكيلي</option>
-                <option value="السداد">السداد</option>
-                <option value="مصرفي">مصرفي</option>
+                <option value="bankily">bankily</option>
+                <option value="sedad">sedad</option>
+                <option value="masrvi">masrvi</option>
             </select>
             <input type="file" class="receipt">
             <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -205,14 +205,14 @@
     <div class="offer-card">
         <img src="image/Googleplay.jpg" alt="Google Play 10$">
         <h3>بطاقة Google Play 10$</h3>
-        <p><span data-i18n="price">السعر:</span> 5 دولار ≈ 200 أوقية</p>
+        <p><span data-i18n="price">السعر:</span> 5 دولار ≈ 200 MRU</p>
         <button data-i18n="order" onclick="showForm(this, 'Google Play', 'بطاقة 10$')">اطلب الآن</button>
         <form>
             <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
             <select class="pay">
-                <option value="بنكيلي">بنكيلي</option>
-                <option value="السداد">السداد</option>
-                <option value="مصرفي">مصرفي</option>
+                <option value="bankily">bankily</option>
+                <option value="sedad">sedad</option>
+                <option value="masrvi">masrvi</option>
             </select>
             <input type="file" class="receipt">
             <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -222,14 +222,14 @@
     <div class="offer-card">
         <img src="image/Googleplay.jpg" alt="Google Play 15$">
         <h3>بطاقة Google Play 15$</h3>
-        <p><span data-i18n="price">السعر:</span> 7.5 دولار ≈ 300 أوقية</p>
+        <p><span data-i18n="price">السعر:</span> 7.5 دولار ≈ 300 MRU</p>
         <button data-i18n="order" onclick="showForm(this, 'Google Play', 'بطاقة 15$')">اطلب الآن</button>
         <form>
             <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
             <select class="pay">
-                <option value="بنكيلي">بنكيلي</option>
-                <option value="السداد">السداد</option>
-                <option value="مصرفي">مصرفي</option>
+                <option value="bankily">bankily</option>
+                <option value="sedad">sedad</option>
+                <option value="masrvi">masrvi</option>
             </select>
             <input type="file" class="receipt">
             <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -239,14 +239,14 @@
     <div class="offer-card">
         <img src="image/Googleplay.jpg" alt="Google Play 25$">
         <h3>بطاقة Google Play 25$</h3>
-        <p><span data-i18n="price">السعر:</span> 12 دولار ≈ 480 أوقية</p>
+        <p><span data-i18n="price">السعر:</span> 12 دولار ≈ 480 MRU</p>
         <button data-i18n="order" onclick="showForm(this, 'Google Play', 'بطاقة 25$')">اطلب الآن</button>
         <form>
             <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
             <select class="pay">
-                <option value="بنكيلي">بنكيلي</option>
-                <option value="السداد">السداد</option>
-                <option value="مصرفي">مصرفي</option>
+                <option value="bankily">bankily</option>
+                <option value="sedad">sedad</option>
+                <option value="masrvi">masrvi</option>
             </select>
             <input type="file" class="receipt">
             <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -256,14 +256,14 @@
     <div class="offer-card">
         <img src="image/Googleplay.jpg" alt="Google Play 50$">
         <h3>بطاقة Google Play 50$</h3>
-        <p><span data-i18n="price">السعر:</span> 23 دولار ≈ 920 أوقية</p>
+        <p><span data-i18n="price">السعر:</span> 23 دولار ≈ 920 MRU</p>
         <button data-i18n="order" onclick="showForm(this, 'Google Play', 'بطاقة 50$')">اطلب الآن</button>
         <form>
             <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
             <select class="pay">
-                <option value="بنكيلي">بنكيلي</option>
-                <option value="السداد">السداد</option>
-                <option value="مصرفي">مصرفي</option>
+                <option value="bankily">bankily</option>
+                <option value="sedad">sedad</option>
+                <option value="masrvi">masrvi</option>
             </select>
             <input type="file" class="receipt">
             <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>

--- a/index.html
+++ b/index.html
@@ -143,11 +143,11 @@
 <header>
     <h1>LD Top-Up</h1>
     <nav>
-        <a href="index.html" data-i18n="nav-home">الرئيسية</a>
-        <a href="pubg.html" data-i18n="nav-pubg">PUBG</a>
-        <a href="freefire.html" data-i18n="nav-freefire">Free Fire</a>
-        <a href="googleplay.html" data-i18n="nav-googleplay">Google Play</a>
-        <a href="itunes.html" data-i18n="nav-itunes">iTunes</a>
+        <a href="index.html">Home</a>
+        <a href="pubg.html">PUBG</a>
+        <a href="freefire.html">Free Fire</a>
+        <a href="googleplay.html">Google Play</a>
+        <a href="itunes.html">iTunes</a>
     </nav>
     <div class="lang-switch">
         <button id="lang-toggle">🌐</button>
@@ -166,19 +166,19 @@
 <section class="categories">
     <div class="category-card" onclick="location.href='pubg.html'">
         <img src="image/UC.jpg" alt="PUBG Mobile">
-        <h3 data-i18n="cat-pubg">PUBG Mobile</h3>
+        <h3>PUBG Mobile</h3>
     </div>
     <div class="category-card" onclick="location.href='freefire.html'">
         <img src="image/Freefire.png" alt="Free Fire">
-        <h3 data-i18n="cat-freefire">Free Fire</h3>
+        <h3>Free Fire</h3>
     </div>
     <div class="category-card" onclick="location.href='googleplay.html'">
         <img src="image/Googleplay.jpg" alt="Google Play">
-        <h3 data-i18n="cat-googleplay">Google Play</h3>
+        <h3>Google Play</h3>
     </div>
     <div class="category-card" onclick="location.href='itunes.html'">
         <img src="image/Itunes.jpg" alt="iTunes">
-        <h3 data-i18n="cat-itunes">iTunes</h3>
+        <h3>iTunes</h3>
     </div>
 </section>
 

--- a/itunes.html
+++ b/itunes.html
@@ -163,11 +163,11 @@
 <header>
     <h1>LD Top-Up</h1>
     <nav>
-        <a href="index.html" data-i18n="nav-home">الرئيسية</a>
-        <a href="pubg.html" data-i18n="nav-pubg">PUBG</a>
-        <a href="freefire.html" data-i18n="nav-freefire">Free Fire</a>
-        <a href="googleplay.html" data-i18n="nav-googleplay">Google Play</a>
-        <a href="itunes.html" data-i18n="nav-itunes">iTunes</a>
+        <a href="index.html">Home</a>
+        <a href="pubg.html">PUBG</a>
+        <a href="freefire.html">Free Fire</a>
+        <a href="googleplay.html">Google Play</a>
+        <a href="itunes.html">iTunes</a>
     </nav>
     <div class="lang-switch">
         <button id="lang-toggle">🌐</button>
@@ -187,14 +187,14 @@
     <div class="offer-card">
         <img src="image/Itunes.jpg">
         <h3>بطاقة $5</h3>
-        <p>190 أوقية</p>
+        <p>190 MRU</p>
         <button data-i18n="order" onclick="showForm(this, 'iTunes', 'بطاقة $5')">اطلب الآن</button>
         <form>
             <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
             <select class="pay">
-                <option value="بنكيلي">بنكيلي</option>
-                <option value="السداد">السداد</option>
-                <option value="مصرفي">مصرفي</option>
+                <option value="bankily">bankily</option>
+                <option value="sedad">sedad</option>
+                <option value="masrvi">masrvi</option>
             </select>
             <input type="file" class="receipt">
             <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -204,14 +204,14 @@
     <div class="offer-card">
         <img src="image/Itunes.jpg">
         <h3>بطاقة $10</h3>
-        <p>380 أوقية</p>
+        <p>380 MRU</p>
         <button data-i18n="order" onclick="showForm(this, 'iTunes', 'بطاقة $10')">اطلب الآن</button>
         <form>
             <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
             <select class="pay">
-                <option value="بنكيلي">بنكيلي</option>
-                <option value="السداد">السداد</option>
-                <option value="مصرفي">مصرفي</option>
+                <option value="bankily">bankily</option>
+                <option value="sedad">sedad</option>
+                <option value="masrvi">masrvi</option>
             </select>
             <input type="file" class="receipt">
             <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -221,14 +221,14 @@
     <div class="offer-card">
         <img src="image/Itunes.jpg">
         <h3>بطاقة $15</h3>
-        <p>570 أوقية</p>
+        <p>570 MRU</p>
         <button data-i18n="order" onclick="showForm(this, 'iTunes', 'بطاقة $15')">اطلب الآن</button>
         <form>
             <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
             <select class="pay">
-                <option value="بنكيلي">بنكيلي</option>
-                <option value="السداد">السداد</option>
-                <option value="مصرفي">مصرفي</option>
+                <option value="bankily">bankily</option>
+                <option value="sedad">sedad</option>
+                <option value="masrvi">masrvi</option>
             </select>
             <input type="file" class="receipt">
             <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -238,14 +238,14 @@
     <div class="offer-card">
         <img src="image/Itunes.jpg">
         <h3>بطاقة $25</h3>
-        <p>950 أوقية</p>
+        <p>950 MRU</p>
         <button data-i18n="order" onclick="showForm(this, 'iTunes', 'بطاقة $25')">اطلب الآن</button>
         <form>
             <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
             <select class="pay">
-                <option value="بنكيلي">بنكيلي</option>
-                <option value="السداد">السداد</option>
-                <option value="مصرفي">مصرفي</option>
+                <option value="bankily">bankily</option>
+                <option value="sedad">sedad</option>
+                <option value="masrvi">masrvi</option>
             </select>
             <input type="file" class="receipt">
             <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -255,14 +255,14 @@
     <div class="offer-card">
         <img src="image/Itunes.jpg">
         <h3>بطاقة $50</h3>
-        <p>1900 أوقية</p>
+        <p>1900 MRU</p>
         <button data-i18n="order" onclick="showForm(this, 'iTunes', 'بطاقة $50')">اطلب الآن</button>
         <form>
             <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
             <select class="pay">
-                <option value="بنكيلي">بنكيلي</option>
-                <option value="السداد">السداد</option>
-                <option value="مصرفي">مصرفي</option>
+                <option value="bankily">bankily</option>
+                <option value="sedad">sedad</option>
+                <option value="masrvi">masrvi</option>
             </select>
             <input type="file" class="receipt">
             <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>

--- a/pubg.html
+++ b/pubg.html
@@ -32,11 +32,11 @@
 
 <header>
   <nav>
-    <a href="index.html" data-i18n="nav-home">الرئيسية</a>
-    <a href="pubg.html" data-i18n="nav-pubg">PUBG</a>
-    <a href="freefire.html" data-i18n="nav-freefire">Free Fire</a>
-    <a href="googleplay.html" data-i18n="nav-googleplay">Google Play</a>
-    <a href="itunes.html" data-i18n="nav-itunes">iTunes</a>
+    <a href="index.html">Home</a>
+    <a href="pubg.html">PUBG</a>
+    <a href="freefire.html">Free Fire</a>
+    <a href="googleplay.html">Google Play</a>
+    <a href="itunes.html">iTunes</a>
   </nav>
   <div class="lang-switch">
     <button id="lang-toggle">🌐</button>
@@ -54,15 +54,15 @@
   <div class="offer">
     <img src="image/UC.jpg" alt="60 UC">
     <h3>60 UC</h3>
-    <p><span data-i18n="price">السعر:</span> 55 أوقية</p>
+    <p><span data-i18n="price">السعر:</span> 55 MRU</p>
     <button data-i18n="order" onclick="showForm(this, 'PUBG', '60 UC')">اطلب الآن</button>
     <form>
       <input type="text" placeholder="رقم اللاعب" class="uid" data-i18n-placeholder="player-id">
       <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
       <select class="pay">
-        <option value="بنكيلي">بنكيلي</option>
-        <option value="السداد">السداد</option>
-        <option value="مصرفي">مصرفي</option>
+        <option value="bankily">bankily</option>
+        <option value="sedad">sedad</option>
+        <option value="masrvi">masrvi</option>
       </select>
       <input type="file" class="receipt">
       <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -73,15 +73,15 @@
   <div class="offer">
     <img src="image/UC.jpg" alt="325 UC">
     <h3>325 UC</h3>
-    <p><span data-i18n="price">السعر:</span> 270 أوقية</p>
+    <p><span data-i18n="price">السعر:</span> 270 MRU</p>
     <button data-i18n="order" onclick="showForm(this, 'PUBG', '325 UC')">اطلب الآن</button>
     <form>
       <input type="text" placeholder="رقم اللاعب" class="uid" data-i18n-placeholder="player-id">
       <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
       <select class="pay">
-        <option value="بنكيلي">بنكيلي</option>
-        <option value="السداد">السداد</option>
-        <option value="مصرفي">مصرفي</option>
+        <option value="bankily">bankily</option>
+        <option value="sedad">sedad</option>
+        <option value="masrvi">masrvi</option>
       </select>
       <input type="file" class="receipt">
       <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -92,15 +92,15 @@
   <div class="offer">
     <img src="image/UC.jpg" alt="660 UC">
     <h3>660 UC</h3>
-    <p><span data-i18n="price">السعر:</span> 540 أوقية</p>
+    <p><span data-i18n="price">السعر:</span> 540 MRU</p>
     <button data-i18n="order" onclick="showForm(this, 'PUBG', '660 UC')">اطلب الآن</button>
     <form>
       <input type="text" placeholder="رقم اللاعب" class="uid" data-i18n-placeholder="player-id">
       <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
       <select class="pay">
-        <option value="بنكيلي">بنكيلي</option>
-        <option value="السداد">السداد</option>
-        <option value="مصرفي">مصرفي</option>
+        <option value="bankily">bankily</option>
+        <option value="sedad">sedad</option>
+        <option value="masrvi">masrvi</option>
       </select>
       <input type="file" class="receipt">
       <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -111,15 +111,15 @@
   <div class="offer">
     <img src="image/UC.jpg" alt="1800 UC">
     <h3>1800 UC</h3>
-    <p><span data-i18n="price">السعر:</span> 1460 أوقية</p>
+    <p><span data-i18n="price">السعر:</span> 1460 MRU</p>
     <button data-i18n="order" onclick="showForm(this, 'PUBG', '1800 UC')">اطلب الآن</button>
     <form>
       <input type="text" placeholder="رقم اللاعب" class="uid" data-i18n-placeholder="player-id">
       <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
       <select class="pay">
-        <option value="بنكيلي">بنكيلي</option>
-        <option value="السداد">السداد</option>
-        <option value="مصرفي">مصرفي</option>
+        <option value="bankily">bankily</option>
+        <option value="sedad">sedad</option>
+        <option value="masrvi">masrvi</option>
       </select>
       <input type="file" class="receipt">
       <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>
@@ -130,15 +130,15 @@
   <div class="offer">
     <img src="image/UC.jpg" alt="3850 UC">
     <h3>3850 UC</h3>
-    <p><span data-i18n="price">السعر:</span> 2920 أوقية</p>
+    <p><span data-i18n="price">السعر:</span> 2920 MRU</p>
     <button data-i18n="order" onclick="showForm(this, 'PUBG', '3850 UC')">اطلب الآن</button>
     <form>
       <input type="text" placeholder="رقم اللاعب" class="uid" data-i18n-placeholder="player-id">
       <input type="text" placeholder="رقم واتسابك" class="whats" data-i18n-placeholder="whats">
       <select class="pay">
-        <option value="بنكيلي">بنكيلي</option>
-        <option value="السداد">السداد</option>
-        <option value="مصرفي">مصرفي</option>
+        <option value="bankily">bankily</option>
+        <option value="sedad">sedad</option>
+        <option value="masrvi">masrvi</option>
       </select>
       <input type="file" class="receipt">
       <button type="button" data-i18n="send" onclick="sendOrder(this)">إرسال الطلب</button>


### PR DESCRIPTION
## Summary
- Show navigation and category labels in English only
- Replace "أوقية" with MRU in all pricing
- Romanize bank payment options as bankily, sedad, and masrvi

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a20ee34c90832aac4b2997f6e2b5a4